### PR TITLE
fix(ResultList): Fix class doesn't exist "ResultList" bug. (Due to module using namespaces)

### DIFF
--- a/code/service/ExtensibleElasticService.php
+++ b/code/service/ExtensibleElasticService.php
@@ -22,11 +22,14 @@ class ExtensibleElasticService extends Symbiote\Elastica\ElasticaService {
         $this->queryBuilders['default'] = 'ElasticaQueryBuilder';
     }
 
-    public function query($query, $offset = 0, $limit = 20, $resultClass = 'ResultList') {
+    public function query($query, $offset = 0, $limit = 20, $resultClass = '') {
         // check for _old_ param structure
-        if (is_array($resultClass) || (is_string($resultClass) && !class_exists($resultClass))) {
-            $resultClass = 'ResultList';
+        if (!$resultClass ||
+            is_array($resultClass) || 
+            is_string($resultClass) && !class_exists($resultClass)) {
+            $resultClass = 'Symbiote\Elastica\ResultList';
         }
+
         if ($query instanceof ElasticaQueryBuilder) {
             $elasticQuery = $query->toQuery();
         } else {


### PR DESCRIPTION
fix(ResultList): Fix class doesn't exist "ResultList" bug. (Due to module using namespaces)

Also changed default parameter value from "ResultList" to "", this is so if more parameters get added later, a developer only needs to provide a "falsey" value to get the default value.