### PR TITLE
mod (PHP 8.1 support)

### DIFF
--- a/src/ElasticaSearchEngine.php
+++ b/src/ElasticaSearchEngine.php
@@ -334,7 +334,7 @@ class ElasticaSearchEngine extends CustomSearchEngine
             $results->setPageStart($offset);
 
             if (count($resultSet->toArray())) {
-                $results->setTotalItems($resultSet->totalItems());
+                $results->setTotalItems($resultSet->getTotalItems());
             }
 
             if (!$resultSet->getResults()) {

--- a/src/ExtensibleElasticService.php
+++ b/src/ExtensibleElasticService.php
@@ -88,7 +88,7 @@ class ExtensibleElasticService extends ElasticaService
         $classes = array();
         foreach (ClassInfo::subclassesFor('SilverStripe\ORM\DataObject') as $candidate) {
             $candidateInstance = singleton($candidate);
-            if (Extensible::has_extension($candidate, 'Heyday\\Elastica\\Searchable')) {
+            if ($candidateInstance->hasExtension('Heyday\\Elastica\\Searchable')) {
                 $classes[] = $candidate;
             }
         }

--- a/src/VersionedReindexTask.php
+++ b/src/VersionedReindexTask.php
@@ -88,7 +88,8 @@ class VersionedReindexTask extends BuildTask
                             $record->reIndex('Stage');
                         }
 
-                        if (Extensible::has_extension($class, Versioned::class)) {
+                        $classInstance = singleton($class);
+                        if ($classInstance->hasExtension(Versioned::class)) {
                             Versioned::set_stage('Live');
                             $live = Versioned::get_by_stage($class, 'Live');
                             foreach ($live as $liveRecord) {


### PR DESCRIPTION
Fixes for deprecation errors when upgrading to PHP 8.1

ElasticaSearchEngine.php
- Change totalItems to getTotalItems to fix error on search pages

ExtensibleElasticService.php
- Fix deprecated has_extension error

VersionedReindexTask.php
- Fix deprecated has_extension error